### PR TITLE
Feat/generate sheet url

### DIFF
--- a/src/components/Create/SheetSection.jsx
+++ b/src/components/Create/SheetSection.jsx
@@ -10,7 +10,18 @@ function SheetSection() {
   const generateUrl = useMutation({
     mutationFn: () =>
       axios.get("/api/projects/generation/sheet", { withCredentials: true }),
-    onSuccess: res => {},
+    onSuccess: res => {
+      const {
+        data: { success },
+      } = res;
+
+      if (success) {
+        sheetUrl.setValue(res.data.sheetUrl);
+      } else {
+        sheetUrl.setValue("");
+        sheetUrl.setError("error");
+      }
+    },
     onError: err => {
       sheetUrl.setError(`Fail connect Database! ${err.response.data.message}`);
     },

--- a/src/hooks/useInput.jsx
+++ b/src/hooks/useInput.jsx
@@ -8,7 +8,7 @@ const useInput = init => {
     setValue(e.target.value);
   };
 
-  return { value, handleChange, error, setError };
+  return { value, setValue, handleChange, error, setError };
 };
 
 export default useInput;

--- a/src/pages/Login/index.jsx
+++ b/src/pages/Login/index.jsx
@@ -1,7 +1,8 @@
 import axios from "axios";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { useMutation } from "@tanstack/react-query";
-import { FaGoogle } from "react-icons/fa";
+import { IoLogoGoogle } from "react-icons/io";
+
 import { firebaseAuth } from "../../utils/firebaseAuth";
 import useAuthStore from "../../stores/useAuthStore";
 
@@ -14,7 +15,7 @@ function Login() {
     const result = await signInWithPopup(firebaseAuth, googleProvider);
     const {
       user: { email, displayName, photoURL, uid },
-      _tokenResponse: { oauthAccessToken, refreshToken },
+      _tokenResponse: { oauthAccessToken, refreshToken: oauthRefreshToken },
     } = result;
     const userInfoObject = {
       email,
@@ -22,7 +23,7 @@ function Login() {
       photoURL,
       uid,
       oauthAccessToken,
-      oauthRefreshToken: refreshToken,
+      oauthRefreshToken,
     };
     const response = await axios.post("/api/users/login", userInfoObject);
 
@@ -45,7 +46,7 @@ function Login() {
         className="text-text-950 font-bold bg-primary-500 hover:bg-primary-600 focus:ring-4 focus:ring-primary-300 font-medium rounded-sm text-base px-5 py-2.5 flex items-center gap-1"
         onClick={mutate}
       >
-        <FaGoogle />
+        <IoLogoGoogle />
         Login with Google
       </button>
     </div>

--- a/src/pages/Login/index.jsx
+++ b/src/pages/Login/index.jsx
@@ -8,16 +8,14 @@ import useAuthStore from "../../stores/useAuthStore";
 function Login() {
   const { setUser } = useAuthStore();
   const googleProvider = new GoogleAuthProvider();
+  googleProvider.addScope(import.meta.env.VITE_GOOGLE_SHEET_SCOPE);
 
   const handleGoogleLogin = async () => {
     const result = await signInWithPopup(firebaseAuth, googleProvider);
-    console.log(result);
-
     const {
       user: { email, displayName, photoURL, uid },
       _tokenResponse: { oauthAccessToken, refreshToken },
     } = result;
-
     const userInfoObject = {
       email,
       displayName,
@@ -26,7 +24,6 @@ function Login() {
       oauthAccessToken,
       oauthRefreshToken: refreshToken,
     };
-
     const response = await axios.post("/api/users/login", userInfoObject);
 
     return response;


### PR DESCRIPTION
close #18 

## 변경 사항
- [x] `generateUrl` `react-query` 수정
- [x] `useInput` 수정
- [x] `react-icons`에러 수정

## 작업 내용

- 버튼 클릭시 서버쪽에서 받은 sheet url을 input창에 커스텀 훅을 이용하여 삽입되도록 작업하였습니다.
- 위에서 받은 url을 넣기 위해 기존 useInput 커스텀훅에 `setValue`속성을 리턴하도록 설정하였습니다.
- 알 수 없는 이유로 갑자기 react-icons 라이브러리에서 구글 아이콘을 사용할 수 없어서 같은 react-icons 라이브러리에서 비슷한 다른 구글 아이콘을 사용하도록 하였습니다.

## 변경 사유

- react-icons의 에러 이유에 대해서 알아보려고 합니다.