### PR TITLE
Feat/projects screen setting

### DIFF
--- a/src/components/Button/LinkButton.jsx
+++ b/src/components/Button/LinkButton.jsx
@@ -1,0 +1,37 @@
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+
+function LinkButton({ to, children }) {
+  return (
+    <Link to={to}>
+      <button
+        type="button"
+        className="font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center bg-background-200"
+      >
+        {children}
+        <svg
+          className="rtl:rotate-180 w-3.5 h-3 ms-2"
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 14 10"
+        >
+          <path
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M1 5h12m0 0L9 1m4 4L9 9"
+          />
+        </svg>
+      </button>
+    </Link>
+  );
+}
+
+LinkButton.propTypes = {
+  to: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default LinkButton;

--- a/src/components/Link/LinkImage.jsx
+++ b/src/components/Link/LinkImage.jsx
@@ -1,0 +1,17 @@
+import { FaExternalLinkAlt } from "react-icons/fa";
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+
+function LinkImage({ to }) {
+  return (
+    <Link to={to}>
+      <FaExternalLinkAlt></FaExternalLinkAlt>
+    </Link>
+  );
+}
+
+LinkImage.propTypes = {
+  to: PropTypes.string.isRequired,
+};
+
+export default LinkImage;

--- a/src/components/Table/TableCell.jsx
+++ b/src/components/Table/TableCell.jsx
@@ -1,0 +1,31 @@
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+
+function TableCell({ label, link, content }) {
+  return (
+    <td className="px-6 py-2 border-2 border-black">
+      <label htmlFor={label}>
+        {link ? (
+          <Link id={label} to={link}>
+            {content}
+          </Link>
+        ) : (
+          content
+        )}
+      </label>
+    </td>
+  );
+}
+
+TableCell.propTypes = {
+  label: PropTypes.string.isRequired,
+  link: PropTypes.string,
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+    .isRequired,
+};
+
+TableCell.defaultProps = {
+  link: null,
+};
+
+export default TableCell;

--- a/src/components/shared/Modal/index.jsx
+++ b/src/components/shared/Modal/index.jsx
@@ -30,8 +30,7 @@ function Modal() {
     e.preventDefault();
     setShow(true);
     // validation
-    console.log(projectInfo);
-    // synchronizeDbToSheet.mutate(projectInfo);
+    synchronizeDbToSheet.mutate(projectInfo);
   };
 
   const handleDisAppearModal = () => {

--- a/src/hooks/useGenerateUrl.jsx
+++ b/src/hooks/useGenerateUrl.jsx
@@ -9,7 +9,7 @@ const useGenerateUrl = () => {
   const SHEET_URL = "sheetUrl";
   const navigate = useNavigate();
   const { setUser } = useAuthStore();
-  const { setInfoValue, setInfoError, setInfoDisabled } = useProjectStore();
+  const { setProjectInfo, setError, setDisabled } = useProjectStore();
 
   const generateSheetUrl = async () => {
     const res = await axios.get("/api/projects/generation/sheet", {
@@ -23,11 +23,11 @@ const useGenerateUrl = () => {
     onSuccess: res => {
       const { sheetUrl } = res.data;
       if (sheetUrl) {
-        setInfoValue({ name: SHEET_URL, value: sheetUrl });
-        setInfoError({ name: SHEET_URL, error: "" });
-        setInfoDisabled({ name: SHEET_URL, disabled: true });
+        setProjectInfo(SHEET_URL, sheetUrl);
+        setError(SHEET_URL, "");
+        setDisabled(SHEET_URL, true);
       } else {
-        setInfoError({
+        setError({
           name: SHEET_URL,
           error: "Error! Failed to generate URL.",
         });
@@ -43,7 +43,7 @@ const useGenerateUrl = () => {
         }
         errorMessage = `Error! ${error.response.data.message || error.response.statusText}`;
       }
-      setInfoError({ name: SHEET_URL, error: errorMessage });
+      setError(SHEET_URL, errorMessage);
     },
   });
 

--- a/src/pages/Projects/LogViewer.jsx
+++ b/src/pages/Projects/LogViewer.jsx
@@ -1,0 +1,37 @@
+const generateLogs = () => {
+  const logs = [];
+
+  for (let i = 0; i < 40; i += 1) {
+    logs.push({
+      projectName: `Project ${i + 1}`,
+      type: i % 2 === 0 ? "Info" : "Error",
+      message: `This is log message ${i + 1}`,
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  return logs;
+};
+
+function LogViewer() {
+  const logs = generateLogs();
+  const logsText = logs
+    .map(
+      log =>
+        `${log.createdAt} | ${log.projectName} | Type: ${log.type} | message: "${log.message}"`,
+    )
+    .join("\n");
+
+  return (
+    <div className="items-center justify-center w-full">
+      <textarea
+        value={logsText}
+        readOnly
+        rows={10}
+        className="w-full border-2 border-gray-300 p-2 overflow-y-scroll mt-3 tracking-widest resize-none"
+      />
+    </div>
+  );
+}
+
+export default LogViewer;

--- a/src/pages/Projects/Pagination.jsx
+++ b/src/pages/Projects/Pagination.jsx
@@ -1,0 +1,44 @@
+import PropTypes from "prop-types";
+import cls from "../../utils/styleUtil";
+
+function Pagination({ totalLength, currentPage, setCurrentPage }) {
+  const totalPages = Math.ceil(totalLength / 5);
+  const currentPageGroup = Math.ceil(currentPage / 5);
+  const startPage = (currentPageGroup - 1) * 5 + 1;
+  const calculatedEndPage = startPage + 5 - 1;
+  const endPage =
+    calculatedEndPage > totalPages ? totalPages : calculatedEndPage;
+
+  return (
+    <nav aria-label="Page navigation example">
+      <ul className="flex items-center -space-x-px h-8 text-sm">
+        {Array.from(
+          { length: endPage - startPage + 1 },
+          (_, i) => startPage + i,
+        ).map(number => (
+          <li key={number}>
+            <button
+              className={cls(
+                "w-8 flex items-center justify-center h-8 leading-tight text-primary-500 border border-primary-950 hover:bg-primary-50 hover:text-primary-900 cursor-pointer",
+                currentPage === number
+                  ? "bg-primary-950 text-white"
+                  : "bg-transparent text-primary-950",
+              )}
+              onClick={() => setCurrentPage(number)}
+            >
+              {number}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+Pagination.propTypes = {
+  totalLength: PropTypes.number.isRequired,
+  currentPage: PropTypes.number.isRequired,
+  setCurrentPage: PropTypes.func.isRequired,
+};
+
+export default Pagination;

--- a/src/pages/Projects/Pagination.jsx
+++ b/src/pages/Projects/Pagination.jsx
@@ -1,11 +1,12 @@
 import PropTypes from "prop-types";
 import cls from "../../utils/styleUtil";
+import { PROJECTS_PER_PAGE } from "../../utils/constants";
 
 function Pagination({ totalLength, currentPage, setCurrentPage }) {
-  const totalPages = Math.ceil(totalLength / 5);
-  const currentPageGroup = Math.ceil(currentPage / 5);
-  const startPage = (currentPageGroup - 1) * 5 + 1;
-  const calculatedEndPage = startPage + 5 - 1;
+  const totalPages = Math.ceil(totalLength / PROJECTS_PER_PAGE);
+  const currentPageGroup = Math.ceil(currentPage / PROJECTS_PER_PAGE);
+  const startPage = (currentPageGroup - 1) * PROJECTS_PER_PAGE + 1;
+  const calculatedEndPage = startPage + PROJECTS_PER_PAGE - 1;
   const endPage =
     calculatedEndPage > totalPages ? totalPages : calculatedEndPage;
 

--- a/src/pages/Projects/ProjectTable.jsx
+++ b/src/pages/Projects/ProjectTable.jsx
@@ -1,0 +1,73 @@
+import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import LinkImage from "../../components/Link/LinkImage";
+import TableCell from "../../components/Table/TableCell";
+
+import formatDate from "../../utils/dateUtil";
+import { PROJECTS_PER_PAGE } from "../../utils/constants";
+
+function ProjectTable({ currentPage, projects }) {
+  return (
+    <table className="w-full text-base text-left rtl:text-right text-text-950 my-2 border-2">
+      <thead className="text-sm text-center text-text-900 uppercase">
+        <tr>
+          <th className="px-6 py-2 border-2 border-black">No.</th>
+          <th className="px-6 py-2 border-2 border-black">Project name</th>
+          <th className="px-6 py-2 border-2 border-black">db Url</th>
+          <th className="px-6 py-2 border-2 border-black">sheet Url</th>
+          <th className="px-6 py-2 border-2 border-black">collection Count</th>
+          <th className="px-6 py-2 border-2 border-black">Created At</th>
+        </tr>
+      </thead>
+      <tbody>
+        {projects.map(
+          (
+            { _id, title, dbUrl, sheetUrl, collectionCount, createdAt },
+            index,
+          ) => (
+            <tr
+              key={_id}
+              className="bg-transparent border-b-2 border-primary-50 text-center text-sm border-2 border-black"
+            >
+              <td className="px-6 py-2 font-medium text-primary-900 whitespace-nowrap border-2 border-black">
+                {(currentPage - 1) * PROJECTS_PER_PAGE + index + 1}
+              </td>
+              <TableCell
+                label={`project_title_${_id}`}
+                link={`/projects/${_id}`}
+                content={title}
+              />
+              <TableCell label={`project_dbUrl_${_id}`} content={dbUrl} />
+              <TableCell
+                label={`project_sheetUrl_${_id}`}
+                content={<LinkImage to={sheetUrl} />}
+              />
+              <TableCell
+                label={`project_collectionCount_${_id}`}
+                content={collectionCount}
+              />
+              <TableCell
+                label={`project_createdAt_${_id}`}
+                content={formatDate(createdAt)}
+              />
+            </tr>
+          ),
+        )}
+      </tbody>
+    </table>
+  );
+}
+
+ProjectTable.propTypes = {
+  currentPage: PropTypes.number.isRequired,
+  projects: PropTypes.arrayOf(
+    PropTypes.shape({
+      _id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      collectionCount: PropTypes.number.isRequired,
+      createdAt: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+};
+
+export default ProjectTable;

--- a/src/pages/Projects/index.jsx
+++ b/src/pages/Projects/index.jsx
@@ -1,9 +1,49 @@
 import useRefetchAuthStatus from "../../hooks/useRefetchAuthStatus";
+import Pagination from "./Pagination";
+import ProjectTable from "./ProjectTable";
+import Spinner from "../../components/shared/Spinner";
+import useUserProjects from "../../hooks/useUserProjects";
+import LogViewer from "./LogViewer";
+import LinkButton from "../../components/Button/LinkButton";
 
 function Projects() {
   useRefetchAuthStatus();
 
-  return <div>Projects</div>;
+  const { currentPage, setCurrentPage, isLoading, isError, error, data } =
+    useUserProjects();
+
+  if (isLoading) return <Spinner />;
+  if (isError) return <div>Error: {error.message}</div>;
+
+  return (
+    <div className="w-7/12 flex-col items-center space-y-2 xl:w-8/12 2xl:w-6/12 mx-auto py-5 max-w-screen-xl">
+      <div className="flex justify-end w-full">
+        <LinkButton to="/projects/new">Create New Project</LinkButton>
+      </div>
+      <h2 className="font-bold text-lg text-text-950 uppercase">My Projects</h2>
+      <div className="flex flex-col relative overflow-x-auto justify-center items-center">
+        {data ? (
+          <>
+            <ProjectTable currentPage={currentPage} projects={data.projects} />
+            <Pagination
+              totalLength={data.projectsLength}
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+              style={{ margin: "auto" }}
+            />
+          </>
+        ) : (
+          <h1>No projects found</h1>
+        )}
+      </div>
+      <div>
+        <h2 className="font-bold text-lg text-text-950 uppercase mt-5">
+          Logs Viewer
+        </h2>
+        <LogViewer />
+      </div>
+    </div>
+  );
 }
 
 export default Projects;


### PR DESCRIPTION
Close #13  

## 변경 사항
- [x] handleSynchronize mutate
- [x] useGenerateUrl 수정
- [x] 사용자 프로필 이미지를 위한 [response 구조](https://github.com/teamblend3/blend-dta-server/compare/dev...feat/handle-user-db?expand=1#diff-04a689bd2ded7f5af5dc0bd5acac2079d50cd0dce7cf15f30cc0076749e6942cR39-R44) 변경
- [x] 상수처리 수정

## 변경 사유
- Table 컴포넌트 속성 설정 위해 tailwind css 속성 추가했습니다.
- 작업 진행중에 서버와의 sync 과정 지속적으로 필요해서 handleSynchronize 함수 내 mutate 실행 상태로 설정했습니다.
- 전역 상태 설정 관련, 어제 리팩토링 해주신 부분에 맞춰 메서드 이름 및 인자 수정 완료했습니다.

## 작업 내용
- [x] /projects 화면 세팅 위한 Projects 컴포넌트 생성했습니다.
- [x] 해당 컴포넌트는 내부에서 프로젝트 생성 페이지로 넘어가는 컴포넌트(LinkButton), 내 프로젝트들 리스트(ProjectTable) 컴포넌트, 구글 시트 내 변동사항을 알려주는 LogViewer 컴포넌트로 구성돼있습니다.
- [x] LinkButton 컴포넌트는 `/projects/new` 페이지로 이동할 수 있는 컴포넌트 입니다.
- [x] ProjectTable 컴포넌트는 내가 만든 프로젝트 리스트를 보여주는 table 로서, 프로젝트에 대한 개략적인 정보와 google sheet url 로 이동할 수 있는 부분들로 나뉘어져 있습니다.
- [x] TableCell 은 각 행에서 이동할 수 있는 링크와 콘텐츠를 재사용성을 높여 다루기 위해 만든 컴포넌트 입니다.
- [x] 서버의 getUserProjects 와의 통신으로 사용자 Model 데이터를 populate 해오고 있습니다. 
- [x] Logviewer 컴포넌트는 구글 시트 단에서 사용자가 데이터를 수정했을 때 변동 사항을 사용자에게 보여주는 컴포넌트 입니다.
- [x] 추후 Google Sheet observe 기능 구현 후, Logviewer 에 표시할 수 있어야 합니다.


## 참고 사항
- 현재 비슷한 기능을 하는 Button 컴포넌트들이 다수 존재합니다. 초기 세팅 시 재사용성을 더 고려했어야 하는데 추후 리팩토링 작업 진행해야 할 것 같습니다.
- ProjectTable 에서 data 정보를 추출하기 위해 서버 파일의 getUserProjects 함수에 변동 사항 생긴 점 있습니다.