### PR TITLE
Refactor/pagination and project updating

### DIFF
--- a/src/components/Pagination/index.jsx
+++ b/src/components/Pagination/index.jsx
@@ -35,7 +35,9 @@ function Pagination({ totalLength, currentPage, setCurrentPage }) {
         ))}
         <NextArrow
           usePage={pathname}
-          onClick={() => setCurrentPage(nextPageGroupFirstPage)}
+          onClick={() =>
+            currentPage > 1 && setCurrentPage(nextPageGroupFirstPage)
+          }
         />
       </ul>
     </nav>

--- a/src/hooks/useGoogleAuth.jsx
+++ b/src/hooks/useGoogleAuth.jsx
@@ -18,7 +18,7 @@ const useGoogleAuth = () => {
     onError: error => {
       console.error("Google login error:", error);
     },
-    scope: "https://www.googleapis.com/auth/spreadsheets",
+    scope: import.meta.env.VITE_GOOGLE_SHEET_SCOPE,
     flow: "auth-code",
   });
 

--- a/src/hooks/useUserProjects.jsx
+++ b/src/hooks/useUserProjects.jsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { useEffect } from "react";
 import { useQueryClient, useQuery } from "@tanstack/react-query";
 
 import {
@@ -25,13 +26,30 @@ const useUserProjects = () => {
     }
   };
 
-  const { isLoading, isError, error, data } = useQuery({
+  const { isLoading, isError, error, data, refetch } = useQuery({
     queryKey: ["user-projects"],
     queryFn: () => fetchProjects(),
     staleTime: USER_PROJECT_STALE_TIME,
     cacheTime: USER_PROJECT_CACHE_TIME,
     enabled: !queryClient.getQueryData(["user-projects"]),
   });
+
+  useEffect(() => {
+    const handleProjectUpdate = async () => {
+      try {
+        const response = await axios.post("/api/createProject");
+
+        if (response.data.success) {
+          await refetch();
+        }
+      } catch (err) {
+        console.err("Project Update failed:", err);
+      }
+    };
+
+    refetch();
+    handleProjectUpdate();
+  }, [refetch]);
 
   return {
     isLoading,


### PR DESCRIPTION
## 작업 사항
- [x] Pagination 페이지 오류 해결
- [x] `GOOGLE_SHEET_SCOPE` 환경변수 설정
- [x] `useUserProject` hook 수정

## 작업 내용
- [x] Pagination 에서 기존 생성된 프로젝트가 0 개일 시(페이지 번호 부여되기 전), 화살표 버튼을 누르면 페이지 번호가 -4, -3, -2, -1, 0 형태로 잘못 생성되고 있었습니다.
- [x] 화살표 버튼 클릭 시 현재 페이지가 1보다 클 경우의 조건을 걸어 해당 오류를 수정했습니다.
- [x] `useGoogleAuth` 내에서 환경변수 설정했습니다.
- [x] 사용자가 프로젝트를 생성하고 생성한 프로젝트를 확인할 수 있는 ”/projects” 혹은 ”/profile” 페이지로 이동 시, 업데이트 상황이 즉시 반영되지 않고 있었습니다.
- [x] useQuery hook 의 `refetch` 함수를 이용해서 해당 쿼리를 다시 호출하여 데이터를 새로 가져오도록 설정했습니다.
- [x] 즉 페이지가 처음 로드 될 시점에는 useEffect 내부에서 `refetch` 를 호출해 초기 프로젝트 목록을 가져오고, 그 후에는 `handleProjectUpdate` 함수에서`refetch` 함수를 호출하여 업데이트된 프로젝트 목록을 가져오는 플로우 입니다.