### PR TITLE
Refactor/create page setting

### DIFF
--- a/src/components/shared/Modal/ModalFooter.jsx
+++ b/src/components/shared/Modal/ModalFooter.jsx
@@ -1,18 +1,45 @@
 import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import { SiGooglesheets } from "react-icons/si";
+import { IoCheckmarkDoneCircleSharp } from "react-icons/io5";
 import Button from "../../Button/Button";
-import { CLOSE_MODAL_BUTTON_STYLE } from "../../../utils/styleConstants";
+import useTaskStatus from "../../../hooks/useTaskStatus";
+import useProjectStore from "../../../stores/useProjectStore";
+import {
+  GO_TO_SHEET_BUTTON_STYLE,
+  CLOSE_MODAL_BUTTON_STYLE,
+} from "../../../utils/styleConstants";
 
 function ModalFooter({ onCloseModal }) {
+  const stepStatus = useTaskStatus();
+  const allStepsDone = stepStatus.every(step => step.done);
+
   return (
     <div className="flex justify-end items-center p-4 md:p-5 border-t border-secondary-400 rounded-b">
-      <Button
-        type="button"
-        onClick={onCloseModal}
-        disabled={false}
-        style={CLOSE_MODAL_BUTTON_STYLE}
-      >
-        Cancel
-      </Button>
+      {allStepsDone ? (
+        <div className="flex items-center">
+          <p className="text-text-850 mr-2">All Done!</p>
+          <IoCheckmarkDoneCircleSharp size={30} />
+        </div>
+      ) : (
+        <Button
+          type="button"
+          onClick={onCloseModal}
+          disabled={false}
+          style={CLOSE_MODAL_BUTTON_STYLE}
+        >
+          Cancel
+        </Button>
+      )}
+
+      {allStepsDone && (
+        <Link to={useProjectStore.getState().projectInfo.sheetUrl}>
+          <Button type="button" style={GO_TO_SHEET_BUTTON_STYLE}>
+            Check your Sheet
+            <SiGooglesheets />
+          </Button>
+        </Link>
+      )}
     </div>
   );
 }

--- a/src/components/shared/Modal/index.jsx
+++ b/src/components/shared/Modal/index.jsx
@@ -10,20 +10,22 @@ import LoadingStep from "../LoadingStep";
 import validateProjectInfo from "../../../utils/validates";
 import Button from "../../Button/Button";
 import { SYNCHRONIZE_BUTTON_STYLE } from "../../../utils/styleConstants";
-import { DUPLICATE_MESSAGE } from "../../../utils/constants";
+import { DUPLICATE_MESSAGE, SHEET_URL } from "../../../utils/constants";
 
 function Modal() {
   const [show, setShow] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
-  const { projectInfo, errors, setError } = useProjectStore(state => ({
-    projectInfo: state.projectInfo,
-    errors: state.errors,
-    disabledFields: state.disabledFields,
-    setProjectInfo: state.setProjectInfo,
-    setError: state.setError,
-    setDisabled: state.setDisabled,
-  }));
+  const { projectInfo, errors, setError, setDisabled } = useProjectStore(
+    state => ({
+      projectInfo: state.projectInfo,
+      errors: state.errors,
+      disabledFields: state.disabledFields,
+      setProjectInfo: state.setProjectInfo,
+      setError: state.setError,
+      setDisabled: state.setDisabled,
+    }),
+  );
 
   const { mutate } = useMutation({
     mutationFn: async data => {
@@ -54,6 +56,7 @@ function Modal() {
     }
     mutate(projectInfo);
     setShow(true);
+    setDisabled(SHEET_URL, true);
   };
 
   const handleDisAppearModal = () => {

--- a/src/utils/styleConstants.js
+++ b/src/utils/styleConstants.js
@@ -13,6 +13,8 @@ export const DEFAULT_BUTTON_STYLE = `${BASE_BUTTON_STYLE} ${BG_PRIMARY} text-tex
 
 export const CLOSE_MODAL_BUTTON_STYLE = `${BASE_BUTTON_STYLE} text-secondary-600 ms-3 bg-secondary-200 hover:bg-secondary-400 hover:text-secondary-700 focus:ring-secondary-600 border border-secondary-400 focus:z-10 rounded-lg`;
 
+export const GO_TO_SHEET_BUTTON_STYLE = `${BASE_BUTTON_STYLE} text-secondary-600 ms-3 bg-secondary-200 hover:bg-secondary-400 hover:text-secondary-700 focus:ring-secondary-600 border border-secondary-400 focus:z-10 rounded-lg`;
+
 export const CLOSE_MODAL_HEADER_BUTTON_STYLE =
   "text-text-400 bg-transparent hover:bg-secondary-200 hover:text-text-900 rounded-lg text-md w-8 h-8 ms-auto inline-flex justify-center items-center";
 


### PR DESCRIPTION
## UI
<img width="1310" alt="스크린샷 2024-02-22 오후 1 21 07" src="https://github.com/teamblend3/blend-dta-client/assets/137036757/4979578d-84e0-4c25-b71d-f939dca06e42">

## 변경 사항
- [x] Modal 내 `setDisabled` 추가
- [x] Modal Footer 내 아이콘 및 버튼 추가
- [x] `styleConstants.js` 스타일 속성 추가

## 작업 내용
- [x] 구글 시트 URL 을 자동으로 생성해주는 방법 외에 사용자가 직접 입력하는 경우도 존재합니다.
- [x] 사용자가 URL 직접 기입 후 Synchronize 버튼을 누른 이후에 URl Input Area 를 수정할 수 없도록 disable 속성으로 변경했습니다.
- [x] Synchronize 성공적으로 완료된 이후, 생성된 시트 URL 로 이동할 수 있는 버튼을 성공했다는 메시지와 함께 Modal Footer 에 추가했습니다.
- [x] 시트 URL 로 이동하는 버튼 스타일을 `styleConstants.js` 파일에 추가했습니다.

## 변경 사유
- Modal Header 에 이미 창 닫기 버튼이 존재합니다. 따라서 Synchronize 성공 이후 Footer 에 있던 Cancel 버튼이 사라지고 Done 메시지와 시트 이동 버튼으로 대체되도록 변경했습니다.
- 어떤 방법이 더 좋은 사용자 경험일지 생각해보고 변경 필요하다면 리팩토링 진행하겠습니다.