### PR TITLE
Feat/pagination query string

### DIFF
--- a/src/components/Profile/UserProject.jsx
+++ b/src/components/Profile/UserProject.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import Pagination from "../Pagination";
 import ProjectTable from "../ProjectsTable";
@@ -6,9 +7,19 @@ import useUserProjects from "../../hooks/useUserProjects";
 import Loading from "../shared/Loading";
 
 function UserProject() {
-  const [currentPage, setCurrentPage] = useState(1);
+  const { search } = useLocation();
+  const navigate = useNavigate();
+  const params = new URLSearchParams(search);
+  const page = params.get("page");
+  const [currentPage, setCurrentPage] = useState(page ? parseInt(page, 10) : 1);
 
   const { isLoading, isError, error, data } = useUserProjects();
+
+  const handlePageChange = newPage => {
+    setCurrentPage(newPage);
+    params.set("page", newPage);
+    navigate(`/profile?${params.toString()}`);
+  };
 
   if (isLoading) return <Loading />;
   if (isError) return <div>Error: {error.message}</div>;
@@ -25,7 +36,7 @@ function UserProject() {
             <Pagination
               totalLength={data.projectsLength}
               currentPage={currentPage}
-              setCurrentPage={setCurrentPage}
+              setCurrentPage={handlePageChange}
             />
           </>
         ) : (

--- a/src/pages/Projects/ProjectsSection.jsx
+++ b/src/pages/Projects/ProjectsSection.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 
 import ProjectTable from "../../components/ProjectsTable";
 import Pagination from "../../components/Pagination";
@@ -6,9 +7,20 @@ import useUserProjects from "../../hooks/useUserProjects";
 import Loading from "../../components/shared/Loading";
 
 function ProjectsSection() {
-  const [currentPage, setCurrentPage] = useState(1);
-
+  const { search } = useLocation();
+  const navigate = useNavigate();
   const { isLoading, isError, error, data } = useUserProjects();
+  const params = new URLSearchParams(search);
+  const page = params.get("page");
+
+  const [currentPage, setCurrentPage] = useState(page ? parseInt(page, 10) : 1);
+
+  const handlePageChange = newPage => {
+    setCurrentPage(newPage);
+    params.set("page", newPage);
+
+    navigate(`${window.location.pathname}?${params.toString()}`);
+  };
 
   if (isLoading) return <Loading />;
   if (isError) return <div>Error: {error.message}</div>;
@@ -24,7 +36,7 @@ function ProjectsSection() {
           <Pagination
             totalLength={data.projectsLength}
             currentPage={currentPage}
-            setCurrentPage={setCurrentPage}
+            setCurrentPage={handlePageChange}
           />
         </>
       ) : (

--- a/src/pages/Projects/ProjectsSection.jsx
+++ b/src/pages/Projects/ProjectsSection.jsx
@@ -18,7 +18,6 @@ function ProjectsSection() {
   const handlePageChange = newPage => {
     setCurrentPage(newPage);
     params.set("page", newPage);
-
     navigate(`${window.location.pathname}?${params.toString()}`);
   };
 


### PR DESCRIPTION
## 작업 사항
- [x] "/profile" 페이지 내 `UserProject` 컴포넌트 query string 추가
- [x] "/projects" 페이지 내 `ProjectsSection` 컴포넌트 query string 추가

## 작업 내용
- [x] Pagination 사용 중인 "/profile", "/projects" 페이지 내에서 페이지 번호를 query string 으로 사용할 수 있도록 작업했습니다.
- [x] `useLocation` 사용하여 현재 URL 의 query string 을 가져왔습니다. 
- [x] `useState` 를 사용해 페이지 번호를 나타내는 상태를 만들고, 초기값으로 URL에서 가져온 page 값을 사용합니다. 이 값이 없으면 1로 초기화됩니다.
- [x] `handlePageChange` 함수를 통해 현재 페이지 상태를 갱신하고, `URLSearchParams` 을 통해 페이지 번호를 query string 에 업데이트합니다. 
- [x] 마지막으로 navigate 함수를 사용하여 페이지를 변경합니다.