### PR TITLE
Refactor/mock auth project

### DIFF
--- a/src/components/Create/MongoSection.jsx
+++ b/src/components/Create/MongoSection.jsx
@@ -41,10 +41,10 @@ function MongoSection() {
   useEffect(() => {
     resetStore();
     if (userId === import.meta.env.VITE_MOCK_AUTH_ID) {
-      setProjectInfo(DB_URL, "cluster0.kbk2xmu.mongodb.net");
-      setProjectInfo(DB_ID, "teamBlend");
-      setProjectInfo(DB_PASSWORD, "HNhA9YPBAiRH68Y6");
-      setProjectInfo(SHEET_URL, "MOCK AUTH CAN'T GENERATE GOOGLE SHEET");
+      setProjectInfo(DB_URL, import.meta.env.VITE_MOCK_DB_URL);
+      setProjectInfo(DB_ID, import.meta.env.VITE_MOCK_DB_ID);
+      setProjectInfo(DB_PASSWORD, import.meta.env.VITE_MOCK_DB_PASSWORD);
+      setProjectInfo(SHEET_URL, import.meta.env.VITE_MOCK_SHEET_URL);
       setDisabled(DB_URL, true);
       setDisabled(DB_ID, true);
       setDisabled(DB_PASSWORD, true);
@@ -107,6 +107,9 @@ function MongoSection() {
         </Button>
       </form>
       {errors[DB_URL] && <FormError errorMessage={errors[DB_URL]} />}
+      {errors[DB_TABLENAME] && (
+        <FormError errorMessage={errors[DB_TABLENAME]} />
+      )}
     </section>
   );
 }

--- a/src/components/Create/SheetSection.jsx
+++ b/src/components/Create/SheetSection.jsx
@@ -44,9 +44,10 @@ function SheetSection() {
         />
         <Button
           type="button"
-          onClick={() =>
-            setProjectInfo(SHEET_URL, "https://www.AUTO_GENERATE.com")
-          }
+          onClick={() => {
+            setProjectInfo(SHEET_URL, "https://www.AUTO_GENERATE.com");
+            setError(SHEET_URL, "");
+          }}
           disabled={Boolean(projectInfo[SHEET_URL])}
         >
           Generate

--- a/src/components/ProjectsTable/TableHead.jsx
+++ b/src/components/ProjectsTable/TableHead.jsx
@@ -21,7 +21,7 @@ function TableHead({ isProjectsPage }) {
         </th>
         {isProjectsPage && (
           <>
-            <th className={cls(thClass, "w-4/12")}>db url</th>
+            <th className={cls(thClass, "w-3/12")}>db url</th>
             <th className={cls(thClass, "w-1/12")}>sheet</th>
           </>
         )}
@@ -31,6 +31,7 @@ function TableHead({ isProjectsPage }) {
         <th className={cls(thClass, isProjectsPage ? "w-2/12" : "w-3/12")}>
           Created At
         </th>
+        {isProjectsPage && <th className={cls(thClass, "w-1/12")}>delete</th>}
       </tr>
     </thead>
   );

--- a/src/components/ProjectsTable/TableRow.jsx
+++ b/src/components/ProjectsTable/TableRow.jsx
@@ -1,8 +1,10 @@
+import axios from "axios";
 import PropTypes from "prop-types";
 import { FaExternalLinkAlt, FaDownload } from "react-icons/fa";
+import { MdDelete } from "react-icons/md";
 import { Link } from "react-router-dom";
-import axios from "axios";
 import { useMutation } from "@tanstack/react-query";
+
 import { PROJECTS_PER_PAGE } from "../../utils/constants";
 import { formatDate } from "../../utils/dataUtil";
 import useAuthStore from "../../stores/useAuthStore";
@@ -29,7 +31,11 @@ function TableRow({ currentPage, project, index, isProjectsPage }) {
   const { mutate, isPending } = useMutation({
     mutationKey: ["get-mock-download"],
     mutationFn: async () => {
-      const res = await axios.get(`/api/projects/${_id}/download`);
+      const res = await axios.get(`/api/projects/${_id}/download`, {
+        responseType:
+          userId === import.meta.env.VITE_MOCK_AUTH_ID ? "blob" : "json",
+        withCredentials: true,
+      });
       return res.data;
     },
     onSuccess: data => {
@@ -50,10 +56,18 @@ function TableRow({ currentPage, project, index, isProjectsPage }) {
     mutate();
   };
 
+  const handleDelete = async () => {
+    const res = await axios.delete(`/api/projects/${_id}`);
+
+    if (res.data.success) {
+      window.location.reload();
+    }
+  };
+
   const renderDownloadButtonOrLink = () => {
     if (sheetUrl && userId === import.meta.env.VITE_MOCK_AUTH_ID) {
       if (isPending) {
-        return <LoadingLine />;
+        return <LoadingLine px={20} />;
       }
       return (
         <button onClick={handleDownLoad} aria-label="download-file">
@@ -91,6 +105,13 @@ function TableRow({ currentPage, project, index, isProjectsPage }) {
       )}
       <td className={cellClass}>{collectionNames?.length}</td>
       <td className={cellClass}>{formatDate(createdAt)}</td>
+      {isProjectsPage && _id && (
+        <td className={cellClass}>
+          <button onClick={handleDelete} aria-label="Delete project">
+            <MdDelete size={18} />
+          </button>
+        </td>
+      )}
     </tr>
   );
 }

--- a/src/components/shared/LoadingLine.jsx
+++ b/src/components/shared/LoadingLine.jsx
@@ -1,9 +1,9 @@
-import React from "react";
+import PropTypes from "prop-types";
 
-function LoadingLine() {
+function LoadingLine({ px }) {
   return (
     <svg
-      className="h-5 w-5 animate-spin stroke-gray mx-auto"
+      className={`h-[${px}px] w-[${px}px] animate-spin stroke-gray mx-auto`}
       viewBox="0 0 256 256"
     >
       <line
@@ -81,5 +81,9 @@ function LoadingLine() {
     </svg>
   );
 }
+
+LoadingLine.propTypes = {
+  px: PropTypes.number.isRequired,
+};
 
 export default LoadingLine;

--- a/src/components/shared/Modal/index.jsx
+++ b/src/components/shared/Modal/index.jsx
@@ -11,7 +11,12 @@ import LoadingStep from "../LoadingStep";
 import { validateProjectInfo } from "../../../utils/validates";
 import Button from "../../Button/Button";
 import { SYNCHRONIZE_BUTTON_STYLE } from "../../../utils/styleConstants";
-import { DUPLICATE_MESSAGE, SHEET_URL } from "../../../utils/constants";
+import {
+  DATABASE_INFO_INCORRECT_MESSAGE,
+  DB_TABLENAME,
+  DUPLICATE_MESSAGE,
+  SHEET_URL,
+} from "../../../utils/constants";
 import useAuthStore from "../../../stores/useAuthStore";
 
 function Modal() {
@@ -40,10 +45,14 @@ function Modal() {
         data,
         {
           responseType:
-            userId === import.meta.env.VITE_MOCK_AUTH_ID ? "blob" : "json",
+            userId === import.meta.env.VITE_MOCK_AUTH_ID &&
+            projectInfo[DB_TABLENAME]
+              ? "blob"
+              : "json",
           withCredentials: true,
         },
       );
+
       return response.data;
     },
     onSuccess: data => {
@@ -59,9 +68,9 @@ function Modal() {
       }
     },
     onError: err => {
+      setShow(false);
       if (err.response.data.message === DUPLICATE_MESSAGE) {
         setErrorMessage(DUPLICATE_MESSAGE);
-        setShow(false);
       }
     },
     onSettled: () => {},
@@ -69,13 +78,21 @@ function Modal() {
 
   const handleSynchronize = e => {
     e.preventDefault();
-    setShow(true);
+
     const isMock = userId === import.meta.env.VITE_MOCK_AUTH_ID;
     const isValid = validateProjectInfo(projectInfo, setError, isMock);
 
     if (!isValid) {
       return;
     }
+
+    if (isMock && !projectInfo[DB_TABLENAME]) {
+      setError(DB_TABLENAME, DATABASE_INFO_INCORRECT_MESSAGE);
+      return;
+    }
+
+    setShow(true);
+
     mutate({ ...projectInfo, statusId: statusId.current });
   };
 

--- a/src/hooks/useValidateDb.jsx
+++ b/src/hooks/useValidateDb.jsx
@@ -49,6 +49,7 @@ const useValidateDb = () => {
         setDisabled(DB_TABLENAME, true);
       }
       setError(DB_URL, "");
+      setError(DB_TABLENAME, "");
     },
     onError: error => {
       setError(DB_URL, error.message);

--- a/src/pages/Collection/Schema.jsx
+++ b/src/pages/Collection/Schema.jsx
@@ -1,8 +1,10 @@
 import axios from "axios";
 import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
-import { RiFileExcel2Line } from "react-icons/ri";
 import { useParams } from "react-router-dom";
+import { useMutation } from "@tanstack/react-query";
+import { RiFileExcel2Line } from "react-icons/ri";
+import LoadingLine from "../../components/shared/LoadingLine";
 
 function Schema({ schemas, collection }) {
   const [selectedRows, setSelectedRows] = useState([]);
@@ -33,47 +35,67 @@ function Schema({ schemas, collection }) {
     setSelectAll(!selectAll);
   };
 
+  const { mutate: downloadMutate, isPending } = useMutation({
+    mutationKey: ["download-excel-schema"],
+    mutationFn: async data => {
+      const res = await axios.post(
+        `/api/projects/${projectId}/download`,
+        {
+          collection: data.collection,
+          columns: data.columns,
+        },
+        {
+          responseType: "blob",
+          withCredentials: true,
+        },
+      );
+      return res.data;
+    },
+    onSuccess: data => {
+      const url = window.URL.createObjectURL(new Blob([data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", `${collection}.xlsx`);
+      document.body.appendChild(link);
+      link.click();
+      link.parentNode.removeChild(link);
+    },
+    onError: error => {
+      console.error("Failed to download file:", error);
+    },
+  });
+
+  console.log(isPending);
+
   const handleSubmit = async e => {
     e.preventDefault();
     if (!selectedRows.length) {
       return;
     }
-    try {
-      const res = await axios.post(
-        `/api/projects/${projectId}/download`,
-        {
-          collection,
-          columns: selectedRows,
-        },
-        { responseType: "blob", withCredentials: true },
-      );
-      const downloadUrl = window.URL.createObjectURL(new Blob([res.data]));
-      const link = document.createElement("a");
-      link.href = downloadUrl;
-      link.setAttribute("download", `${collection}.xlsx`);
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(downloadUrl);
-    } catch (error) {
-      console.error("Failed to download file:", error);
-    }
+    downloadMutate({
+      collection,
+      columns: selectedRows,
+    });
   };
 
   return (
     <div className="flex flex-col w-full h-full space-y-2">
       <div className="flex items-center">
         <h3 className="text-text-800 font-bold flex-grow">Data Schema</h3>
-        <button
-          type="button"
-          onClick={handleSubmit}
-          aria-label="Download Excel"
-        >
-          <RiFileExcel2Line
-            className="flex-shrink-0 text-primary-500"
-            size="25"
-          />
-        </button>
+        {isPending ? (
+          <LoadingLine px={25} />
+        ) : (
+          <button
+            type="button"
+            onClick={handleSubmit}
+            aria-label="Download Excel"
+          >
+            <RiFileExcel2Line
+              className="flex-shrink-0 text-primary-500"
+              size="25"
+            />
+          </button>
+        )}
       </div>
       <table className="w-full h-full text-sm text-center text-text-950 my-2 border border-collapse">
         <thead className="text-sm uppercase border border-collapse">

--- a/src/pages/Collection/index.jsx
+++ b/src/pages/Collection/index.jsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 
 import DataSection from "./DataSection";
 import SelectSection from "./SelectSection";
@@ -8,11 +8,9 @@ import Container from "../../components/Layout/Container";
 
 function Collection() {
   const { projectId } = useParams();
-  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
-  const params = new URLSearchParams(location.search);
-  const selectedCollection = params.get("collection");
-
+  const selectedCollection = searchParams.get("collection");
   const {
     collection,
     setCollection,
@@ -34,8 +32,8 @@ function Collection() {
   const handleCollectionChange = newCollection => {
     setCollection(newCollection);
 
-    params.set("collection", newCollection);
-    navigate(`/projects/${projectId}?${params.toString()}`);
+    setSearchParams({ collection: newCollection });
+    navigate(`/projects/${projectId}?collection=${newCollection}`);
   };
 
   if (isLoading) return <Loading />;
@@ -47,7 +45,7 @@ function Collection() {
   return (
     <Container>
       <h1 className="font-bold text-2xl text-text-950 uppercase">
-        Project Details
+        [{project.title}] Project Details
       </h1>
       <SelectSection
         list={project.collectionNames}

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function NotFound() {
+  return <div>NotFound</div>;
+}
+
+export default NotFound;

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -9,6 +9,7 @@ import CollectionPage from "./pages/Collection";
 import useAuthStore from "./stores/useAuthStore";
 import useAuthStatus from "./hooks/useAuthStatus";
 import Loading from "./components/shared/Loading";
+import NotFound from "./pages/NotFound";
 
 function PrivateRoute() {
   const { isLoading } = useAuthStatus();
@@ -51,6 +52,7 @@ const routes = [
           { path: "/projects/:projectId", element: <CollectionPage /> },
         ],
       },
+      { path: "*", element: <NotFound /> },
     ],
   },
 ];

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -12,3 +12,5 @@ export const DATA_FORMATTING_DONE = "DATA_FORMATTING_DONE";
 export const TRANSFER_DATA_DONE = "TRANSFER_DATA_DONE";
 export const DUPLICATE_MESSAGE =
   "You already have selected Table already exists.";
+export const DATABASE_INFO_INCORRECT_MESSAGE =
+  "The database information entered is incorrect.";

--- a/src/utils/validates.js
+++ b/src/utils/validates.js
@@ -1,5 +1,5 @@
 import Joi from "joi";
-import { DB_URL, SHEET_URL } from "./constants";
+import { DB_TABLENAME, DB_URL, SHEET_URL } from "./constants";
 
 export const validateField = (field, value) => {
   let schema;


### PR DESCRIPTION
## 변경 사항
- [x] Mock auth login 시 create project 할 때, project info validate
- [x] Project delete 기능 추가
- [x] Mock auth 시 Download excel file 할 동안 LoadingLine Component 추가
- [x] 기존 query string 이용할시 useSearchParams hook을 사용하여 변경
- [x] NotFound page component 추가 및 Route 추가
- [x] constants 추가

## 작업 내용

- 기존 목업 계정시 테이블네임이 없어도 싱크되는 현상이 있어서 검증을 거쳐 테이블이 선택되지 않으면 싱크되지 않도록 하였습니다.
- 프로젝트 삭제하는 아이콘을 Projects table에 추가하였습니다.
- 파일을 다운로드 하는 과정에서 아무런 효과가 없어서 유저 경험이 떨어지는 면이 있었는데, 로딩되는 아이콘을 추가하여, 유저 경험을 향상하려고 하였습니다.
- NotFound 페이지가 없어서 추가하였고, 라우터를 변경하여, 없는 주소로 접근시 이동하도록 작업하였습니다.
- 기존 목업 계정 데이터 베이스 주소가 오픈되어 변경하고 .env파일로 관리하였습니다.

## 참고 사항

- NotFound page component 작업 부탁드립니다.
- UserProfile table 에서도 useSearchParams hook으로 작업부탁드립니다.